### PR TITLE
Remove legacy Procfile instructions

### DIFF
--- a/src/_posts/continuously-deploy-node-apps-with-github-travis-and-heroku.md
+++ b/src/_posts/continuously-deploy-node-apps-with-github-travis-and-heroku.md
@@ -72,10 +72,6 @@ By default Travis will try to deploy to a Heroku application with the same name 
         secure: FF7yK....
 
 Commit the file to your git repository and push the file up to GitHub.
-
-Finally for an application to work on Heroku it needs a `Procfile`. This is so Heroku knows how to start a Node.js application. For the example project you can see this file [here][12]
-
-    web: node app.js
     
 ## The build and deployment pipeline
 


### PR DESCRIPTION
The Procfile is no longer required to run a node app on Heroku, as long as 'npm start' is specified. See https://devcenter.heroku.com/changelog-items/370
